### PR TITLE
Update HatSploit URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h3 align="center"><img src="https://hatsploit.netlify.app/images/logo-footer.png" alt="logo" height="250px"></h3>
+<h3 align="center"><img src="https://hatsploit.com/images/logo-footer.png" alt="logo" height="250px"></h3>
 
 <p align="center">
     <b>HatSploit Framework</b><br>

--- a/hatsploit/commands/advanced.py
+++ b/hatsploit/commands/advanced.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/api.py
+++ b/hatsploit/commands/api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/back.py
+++ b/hatsploit/commands/back.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/banner.py
+++ b/hatsploit/commands/banner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/clear.py
+++ b/hatsploit/commands/clear.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/encoder_db.py
+++ b/hatsploit/commands/encoder_db.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/encoders.py
+++ b/hatsploit/commands/encoders.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/exec.py
+++ b/hatsploit/commands/exec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/exit.py
+++ b/hatsploit/commands/exit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/help.py
+++ b/hatsploit/commands/help.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/history.py
+++ b/hatsploit/commands/history.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/info.py
+++ b/hatsploit/commands/info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/jobs.py
+++ b/hatsploit/commands/jobs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/load.py
+++ b/hatsploit/commands/load.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/log.py
+++ b/hatsploit/commands/log.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/loot.py
+++ b/hatsploit/commands/loot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/module_db.py
+++ b/hatsploit/commands/module_db.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/modules.py
+++ b/hatsploit/commands/modules.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/options.py
+++ b/hatsploit/commands/options.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/payload_db.py
+++ b/hatsploit/commands/payload_db.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/payloads.py
+++ b/hatsploit/commands/payloads.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/plugin_db.py
+++ b/hatsploit/commands/plugin_db.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/plugins.py
+++ b/hatsploit/commands/plugins.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/repeat.py
+++ b/hatsploit/commands/repeat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/run.py
+++ b/hatsploit/commands/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/search.py
+++ b/hatsploit/commands/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/sessions.py
+++ b/hatsploit/commands/sessions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/set.py
+++ b/hatsploit/commands/set.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/sleep.py
+++ b/hatsploit/commands/sleep.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/storage.py
+++ b/hatsploit/commands/storage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/tip.py
+++ b/hatsploit/commands/tip.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/unload.py
+++ b/hatsploit/commands/unload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/commands/use.py
+++ b/hatsploit/commands/use.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This command requires HatSploit: https://hatsploit.netlify.app
+# This command requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/encoders/generic/base64.py
+++ b/hatsploit/encoders/generic/base64.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/encoders/x64/xor.py
+++ b/hatsploit/encoders/x64/xor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/auxiliary/android/checker/check_adb_installation.py
+++ b/hatsploit/modules/auxiliary/android/checker/check_adb_installation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/auxiliary/apple_ios/checker/jailbroken_or_not.py
+++ b/hatsploit/modules/auxiliary/apple_ios/checker/jailbroken_or_not.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/auxiliary/generic/generator/payload.py
+++ b/hatsploit/modules/auxiliary/generic/generator/payload.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/auxiliary/generic/scanner/directory_scanner.py
+++ b/hatsploit/modules/auxiliary/generic/scanner/directory_scanner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/auxiliary/generic/scanner/port_scanner.py
+++ b/hatsploit/modules/auxiliary/generic/scanner/port_scanner.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/android/adb/remote_code_execution.py
+++ b/hatsploit/modules/exploit/android/adb/remote_code_execution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/apple_ios/safari/webkit_filter_dos.py
+++ b/hatsploit/modules/exploit/apple_ios/safari/webkit_filter_dos.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/apple_ios/ssh/cydia_default_password.py
+++ b/hatsploit/modules/exploit/apple_ios/ssh/cydia_default_password.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/generic/gather/browser_webcam_photo.py
+++ b/hatsploit/modules/exploit/generic/gather/browser_webcam_photo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/generic/gather/browser_webcam_stream.py
+++ b/hatsploit/modules/exploit/generic/gather/browser_webcam_stream.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/generic/handler/bind_tcp.py
+++ b/hatsploit/modules/exploit/generic/handler/bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/generic/handler/multi_reverse_tcp.py
+++ b/hatsploit/modules/exploit/generic/handler/multi_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/generic/handler/reverse_tcp.py
+++ b/hatsploit/modules/exploit/generic/handler/reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/generic/ssh/server_code_execution.py
+++ b/hatsploit/modules/exploit/generic/ssh/server_code_execution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/3com/ap8670_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/3com/ap8670_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/antiweb/path_traversal.py
+++ b/hatsploit/modules/exploit/linux/antiweb/path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/apache/nifi_api_rce.py
+++ b/hatsploit/modules/exploit/linux/apache/nifi_api_rce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/asus/multi_password_disclosure.py
+++ b/hatsploit/modules/exploit/linux/asus/multi_password_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/avtech/ipcamera_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/avtech/ipcamera_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/avtech/ipcamera_information_disclosure.py
+++ b/hatsploit/modules/exploit/linux/avtech/ipcamera_information_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/brickcom/multi_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/brickcom/multi_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/cypress/ctm_backdoor_password.py
+++ b/hatsploit/modules/exploit/linux/cypress/ctm_backdoor_password.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/dlink/dap_2020_path_traversal.py
+++ b/hatsploit/modules/exploit/linux/dlink/dap_2020_path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/dlink/dcs_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/dlink/dcs_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/dlink/dir645_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/dlink/dir645_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/dlink/hedwig_code_execution.py
+++ b/hatsploit/modules/exploit/linux/dlink/hedwig_code_execution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/f5/bigip_tmui_path_traversal.py
+++ b/hatsploit/modules/exploit/linux/f5/bigip_tmui_path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/f5/bigip_tmui_rce.py
+++ b/hatsploit/modules/exploit/linux/f5/bigip_tmui_rce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/fhem/path_traversal.py
+++ b/hatsploit/modules/exploit/linux/fhem/path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/generic/32764_code_execution.py
+++ b/hatsploit/modules/exploit/linux/generic/32764_code_execution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/generic/32764_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/generic/32764_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/generic/dvr_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/generic/dvr_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/generic/p2p_authenticated_rce.py
+++ b/hatsploit/modules/exploit/linux/generic/p2p_authenticated_rce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/generic/p2p_password_disclosure.py
+++ b/hatsploit/modules/exploit/linux/generic/p2p_password_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/huawei/hg630_information_disclosure.py
+++ b/hatsploit/modules/exploit/linux/huawei/hg630_information_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/icewarp/webmail_path_traversal.py
+++ b/hatsploit/modules/exploit/linux/icewarp/webmail_path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/jvc/t216vpru_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/jvc/t216vpru_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/jvc/t216vpru_path_traversal.py
+++ b/hatsploit/modules/exploit/linux/jvc/t216vpru_path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/linksys/eseries_tmunblock_rce.py
+++ b/hatsploit/modules/exploit/linux/linksys/eseries_tmunblock_rce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/linksys/wap54gv3_debug_rce.py
+++ b/hatsploit/modules/exploit/linux/linksys/wap54gv3_debug_rce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/messagesolution/eea_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/messagesolution/eea_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/mikrotik/winbox_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/mikrotik/winbox_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/movistar/adsl_path_traversal.py
+++ b/hatsploit/modules/exploit/linux/movistar/adsl_path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/netwave/ipcamera_information_disclosure.py
+++ b/hatsploit/modules/exploit/linux/netwave/ipcamera_information_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/netwave/wpa_information_disclosure.py
+++ b/hatsploit/modules/exploit/linux/netwave/wpa_information_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/nostromo/remote_code_execution.py
+++ b/hatsploit/modules/exploit/linux/nostromo/remote_code_execution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/oracle/weblogic_console_rce.py
+++ b/hatsploit/modules/exploit/linux/oracle/weblogic_console_rce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/rompager/multi_password_disclosure.py
+++ b/hatsploit/modules/exploit/linux/rompager/multi_password_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/selea/anpr_authenticated_rce.py
+++ b/hatsploit/modules/exploit/linux/selea/anpr_authenticated_rce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/selea/anpr_password_disclosure.py
+++ b/hatsploit/modules/exploit/linux/selea/anpr_password_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/selea/anpr_path_traversal.py
+++ b/hatsploit/modules/exploit/linux/selea/anpr_path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/siemens/multi_credentials_disclosure.py
+++ b/hatsploit/modules/exploit/linux/siemens/multi_credentials_disclosure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/siemens/multi_path_traversal.py
+++ b/hatsploit/modules/exploit/linux/siemens/multi_path_traversal.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/ssh/libssh_code_execution.py
+++ b/hatsploit/modules/exploit/linux/ssh/libssh_code_execution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/ssh/raspbian_default_credentials.py
+++ b/hatsploit/modules/exploit/linux/ssh/raspbian_default_credentials.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/wepresent/wipg1000_code_execution.py
+++ b/hatsploit/modules/exploit/linux/wepresent/wipg1000_code_execution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/linux/zte/f460_f660_rce.py
+++ b/hatsploit/modules/exploit/linux/zte/f460_f660_rce.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/windows/handler/bitsadmin_reverse_http.py
+++ b/hatsploit/modules/exploit/windows/handler/bitsadmin_reverse_http.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/windows/handler/mshta_reverse_http.py
+++ b/hatsploit/modules/exploit/windows/handler/mshta_reverse_http.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/windows/handler/regsvr32_reverse_http.py
+++ b/hatsploit/modules/exploit/windows/handler/regsvr32_reverse_http.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/windows/handler/wmic_reverse_http.py
+++ b/hatsploit/modules/exploit/windows/handler/wmic_reverse_http.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/windows/http/http_sys_dos.py
+++ b/hatsploit/modules/exploit/windows/http/http_sys_dos.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/exploit/windows/smb/ms17_010_eternalblue.py
+++ b/hatsploit/modules/exploit/windows/smb/ms17_010_eternalblue.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/post/apple_ios/shell/respring.py
+++ b/hatsploit/modules/post/apple_ios/shell/respring.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/post/apple_ios/shell/safari_bookmarks.py
+++ b/hatsploit/modules/post/apple_ios/shell/safari_bookmarks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/post/apple_ios/shell/safari_history.py
+++ b/hatsploit/modules/post/apple_ios/shell/safari_history.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/post/macos/shell/suspend.py
+++ b/hatsploit/modules/post/macos/shell/suspend.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/post/unix/shell/getpasswd.py
+++ b/hatsploit/modules/post/unix/shell/getpasswd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/post/unix/shell/getpid.py
+++ b/hatsploit/modules/post/unix/shell/getpid.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/modules/post/windows/shell/message_box.py
+++ b/hatsploit/modules/post/windows/shell/message_box.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This module requires HatSploit: https://hatsploit.netlify.app
+# This module requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/apple_ios/aarch64/pwny_bind_tcp.py
+++ b/hatsploit/payloads/apple_ios/aarch64/pwny_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/apple_ios/aarch64/pwny_reverse_tcp.py
+++ b/hatsploit/payloads/apple_ios/aarch64/pwny_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/aarch64/shell_bind_tcp.py
+++ b/hatsploit/payloads/linux/aarch64/shell_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/aarch64/shell_reverse_tcp.py
+++ b/hatsploit/payloads/linux/aarch64/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/armle/fork_bomb.py
+++ b/hatsploit/payloads/linux/armle/fork_bomb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/armle/shell_bind_tcp.py
+++ b/hatsploit/payloads/linux/armle/shell_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/armle/shell_reverse_tcp.py
+++ b/hatsploit/payloads/linux/armle/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/generic/fork_bomb.py
+++ b/hatsploit/payloads/linux/generic/fork_bomb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/mipsbe/reboot.py
+++ b/hatsploit/payloads/linux/mipsbe/reboot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/mipsbe/shell_bind_tcp.py
+++ b/hatsploit/payloads/linux/mipsbe/shell_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/mipsbe/shell_reverse_tcp.py
+++ b/hatsploit/payloads/linux/mipsbe/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/mipsle/reboot.py
+++ b/hatsploit/payloads/linux/mipsle/reboot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/mipsle/shell_bind_tcp.py
+++ b/hatsploit/payloads/linux/mipsle/shell_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/mipsle/shell_reverse_tcp.py
+++ b/hatsploit/payloads/linux/mipsle/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/fork_bomb.py
+++ b/hatsploit/payloads/linux/x64/fork_bomb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/kill_all.py
+++ b/hatsploit/payloads/linux/x64/kill_all.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/monhorn_bind_tcp.py
+++ b/hatsploit/payloads/linux/x64/monhorn_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/monhorn_reverse_tcp.py
+++ b/hatsploit/payloads/linux/x64/monhorn_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/pwny_bind_tcp.py
+++ b/hatsploit/payloads/linux/x64/pwny_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/pwny_reverse_tcp.py
+++ b/hatsploit/payloads/linux/x64/pwny_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/reboot.py
+++ b/hatsploit/payloads/linux/x64/reboot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/shell_bind_tcp.py
+++ b/hatsploit/payloads/linux/x64/shell_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/shell_reverse_tcp.py
+++ b/hatsploit/payloads/linux/x64/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x64/shutdown.py
+++ b/hatsploit/payloads/linux/x64/shutdown.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x86/monhorn_bind_tcp.py
+++ b/hatsploit/payloads/linux/x86/monhorn_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x86/monhorn_reverse_tcp.py
+++ b/hatsploit/payloads/linux/x86/monhorn_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x86/pwny_bind_tcp.py
+++ b/hatsploit/payloads/linux/x86/pwny_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x86/pwny_reverse_tcp.py
+++ b/hatsploit/payloads/linux/x86/pwny_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x86/shell_bind_tcp.py
+++ b/hatsploit/payloads/linux/x86/shell_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/linux/x86/shell_reverse_tcp.py
+++ b/hatsploit/payloads/linux/x86/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/macos/applescript/shell_reverse_tcp.py
+++ b/hatsploit/payloads/macos/applescript/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/macos/generic/applescript_reverse_tcp.py
+++ b/hatsploit/payloads/macos/generic/applescript_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/macos/x64/pwny_bind_tcp.py
+++ b/hatsploit/payloads/macos/x64/pwny_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/macos/x64/pwny_reverse_tcp.py
+++ b/hatsploit/payloads/macos/x64/pwny_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/macos/x64/say.py
+++ b/hatsploit/payloads/macos/x64/say.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/macos/x64/shell_bind_tcp.py
+++ b/hatsploit/payloads/macos/x64/shell_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/macos/x64/shell_reverse_tcp.py
+++ b/hatsploit/payloads/macos/x64/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/bash_reverse_tcp.py
+++ b/hatsploit/payloads/unix/generic/bash_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/ksh_reverse_tcp.py
+++ b/hatsploit/payloads/unix/generic/ksh_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/netcat_reverse_tcp.py
+++ b/hatsploit/payloads/unix/generic/netcat_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/netcate_reverse_tcp.py
+++ b/hatsploit/payloads/unix/generic/netcate_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/perl_reverse_tcp.py
+++ b/hatsploit/payloads/unix/generic/perl_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/php_reverse_tcp.py
+++ b/hatsploit/payloads/unix/generic/php_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/reboot.py
+++ b/hatsploit/payloads/unix/generic/reboot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/ruby_reverse_tcp.py
+++ b/hatsploit/payloads/unix/generic/ruby_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/zsh_bind_tcp.py
+++ b/hatsploit/payloads/unix/generic/zsh_bind_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/unix/generic/zsh_reverse_tcp.py
+++ b/hatsploit/payloads/unix/generic/zsh_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/windows/generic/calc.py
+++ b/hatsploit/payloads/windows/generic/calc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/windows/generic/message_box.py
+++ b/hatsploit/payloads/windows/generic/message_box.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/windows/generic/powershell_reverse_tcp.py
+++ b/hatsploit/payloads/windows/generic/powershell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/windows/generic/say.py
+++ b/hatsploit/payloads/windows/generic/say.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/windows/x64/shell_reverse_tcp.py
+++ b/hatsploit/payloads/windows/x64/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/payloads/windows/x86/shell_reverse_tcp.py
+++ b/hatsploit/payloads/windows/x86/shell_reverse_tcp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This payload requires HatSploit: https://hatsploit.netlify.app
+# This payload requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/plugins/cowsay.py
+++ b/hatsploit/plugins/cowsay.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This plugin requires HatSploit: https://hatsploit.netlify.app
+# This plugin requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 

--- a/hatsploit/plugins/ngrok.py
+++ b/hatsploit/plugins/ngrok.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# This plugin requires HatSploit: https://hatsploit.netlify.app
+# This plugin requires HatSploit: https://hatsploit.com
 # Current source: https://github.com/EntySec/HatSploit
 #
 


### PR DESCRIPTION
A new hatsploit.com domain now redirects to https://hatsploit.netlify.app. Update all HatSploit URLs to point to
this domain.