### PR TITLE
Add `http_methods` module

### DIFF
--- a/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
+++ b/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
@@ -6,7 +6,7 @@
 #
 
 import urllib.request
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 from hatsploit.lib.module import Module
 
@@ -58,8 +58,10 @@ class HatSploitModule(Module):
                     resp = urllib.request.urlopen(req)
                     if resp.status == 200:
                         self.supported_methods[str(port)].append(method)
-                except HTTPError:
+                except (HTTPError, URLError):
                     continue
 
-        print(f'Port 80 Supported Methods: {" ".join(supported_methods["80"])}')
-        print(f'Port 443 Supported Methods: {" ".join(supported_methods["443"])}')
+        if len(self.supported_methods['80']):
+            print(f'Port 80 Supported Methods: {" ".join(self.supported_methods["80"])}')
+        if len(self.supported_methods['443']):
+            print(f'Port 443 Supported Methods: {" ".join(self.supported_methods["443"])}')

--- a/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
+++ b/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
@@ -42,7 +42,7 @@ class HatSploitModule(HTTPClient, Module, TCPTools):
         'TRACE',
     ]
 
-    supported_methods = {'80': [], '443': []}
+    supported_methods = {'80': [], '443': [], 'count': 0}
 
     def run(self):
         remote_host = self.parse_options(self.options)
@@ -61,16 +61,14 @@ class HatSploitModule(HTTPClient, Module, TCPTools):
                     if resp:
                         if resp.status_code == 200:
                             self.supported_methods[str(port)].append(method)
-        count = 0
+                            self.supported_methods['count'] += 1
         if len(self.supported_methods['80']):
-            count += 1
             self.print_success(
                 f'Port 80 Supported Methods: {" ".join(self.supported_methods["80"])}'
             )
         if len(self.supported_methods['443']):
-            count += 1
             self.print_success(
                 f'Port 443 Supported Methods: {" ".join(self.supported_methods["443"])}'
             )
-        if count == 0:
+        if self.supported_methods['count'] == 0:
             self.print_error('No supported HTTP methods detected')

--- a/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
+++ b/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
@@ -62,10 +62,10 @@ class HatSploitModule(Module):
                     continue
 
         if len(self.supported_methods['80']):
-            print(
+            self.print_success(
                 f'Port 80 Supported Methods: {" ".join(self.supported_methods["80"])}'
             )
         if len(self.supported_methods['443']):
-            print(
+            self.print_success(
                 f'Port 443 Supported Methods: {" ".join(self.supported_methods["443"])}'
             )

--- a/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
+++ b/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
@@ -61,11 +61,16 @@ class HatSploitModule(HTTPClient, Module, TCPTools):
                     if resp:
                         if resp.status_code == 200:
                             self.supported_methods[str(port)].append(method)
+        count = 0
         if len(self.supported_methods['80']):
+            count += 1
             self.print_success(
                 f'Port 80 Supported Methods: {" ".join(self.supported_methods["80"])}'
             )
         if len(self.supported_methods['443']):
+            count += 1
             self.print_success(
                 f'Port 443 Supported Methods: {" ".join(self.supported_methods["443"])}'
             )
+        if count == 0:
+            self.print_error('No supported HTTP methods detected')

--- a/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
+++ b/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
@@ -62,6 +62,10 @@ class HatSploitModule(Module):
                     continue
 
         if len(self.supported_methods['80']):
-            print(f'Port 80 Supported Methods: {" ".join(self.supported_methods["80"])}')
+            print(
+                f'Port 80 Supported Methods: {" ".join(self.supported_methods["80"])}'
+            )
         if len(self.supported_methods['443']):
-            print(f'Port 443 Supported Methods: {" ".join(self.supported_methods["443"])}')
+            print(
+                f'Port 443 Supported Methods: {" ".join(self.supported_methods["443"])}'
+            )

--- a/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
+++ b/hatsploit/modules/auxiliary/generic/scanner/http_methods.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+#
+# This module requires HatSploit: https://hatsploit.com
+# Current source: https://github.com/EntySec/HatSploit
+#
+
+import urllib.request
+from urllib.error import HTTPError
+
+from hatsploit.lib.module import Module
+
+
+class HatSploitModule(Module):
+    details = {
+        'Category': 'auxiliary',
+        'Name': 'HTTP Methods',
+        'Module': 'auxiliary/generic/scanner/http_methods',
+        'Authors': ['Noah Altunian (naltun) - contributor'],
+        'Description': 'Find supported HTTP methods on a server',
+        'Platform': 'generic',
+        'Rank': 'low',
+    }
+
+    options = {
+        'HOST': {
+            'Description': 'Remote host.',
+            'Value': None,
+            'Type': 'ip',
+            'Required': True,
+        }
+    }
+
+    http_methods = [
+        'CONNECT',
+        'DELETE',
+        'GET',
+        'HEAD',
+        'OPTIONS',
+        'PATCH',
+        'POST',
+        'PUT',
+        'TRACE',
+    ]
+
+    supported_methods = {'80': [], '443': []}
+
+    def run(self):
+        remote_host = self.parse_options(self.options)
+
+        self.print_process(f'Scanning {remote_host}...')
+        for method in self.http_methods:
+            for port in [80, 443]:
+                try:
+                    req = urllib.request.Request(
+                        url=f'http://{remote_host}:{port}', method=method
+                    )
+                    resp = urllib.request.urlopen(req)
+                    if resp.status == 200:
+                        self.supported_methods[str(port)].append(method)
+                except HTTPError:
+                    continue
+
+        print(f'Port 80 Supported Methods: {" ".join(supported_methods["80"])}')
+        print(f'Port 443 Supported Methods: {" ".join(supported_methods["443"])}')


### PR DESCRIPTION
Add the `auxiliary/generic/scanner/http_methods` module. From the description:

```
Find supported HTTP methods on a server.
```

The idea is that this module will show you which HTTP methods are available on ports 80 and 443, respectively. Here it is running on my box:

```sh
(hsf)> use auxiliary/generic/scanner/http_methods
(hsf: auxiliary: HTTP Methods)> set HOST 45.33.32.156 # scanme.nmap.org
[i] HOST ==> 45.33.32.156
(hsf: auxiliary: HTTP Methods)> run

[*] Scanning 45.33.32.156...
[+] Port 80 Supported Methods: GET HEAD OPTIONS POST
[+] Auxiliary module completed!
```

Edit 1: If there are any quality-of-life methods from the `Module` or `TCPTools` classes that I am not using but should, let me know.

Edit 2: Update May 27

<img width="399" alt="image" src="https://user-images.githubusercontent.com/7507990/170792175-df560f0a-9d59-4a39-9b9b-e6d479187157.png">
